### PR TITLE
Implement compatibility with React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "jest": "^22.1.4",
     "jest-cli": "^22.1.4",
     "less": "^2.7.3",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0"
   },
   "peerDependencies": {
     "react": ">=15.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "lodash.once": "^4.1.1",
     "merge-class-names": "^1.1.1",
     "prop-types": "^15.6.0",
-    "react-clock": "^2.2.1"
+    "react-clock": "^2.2.1",
+    "react-lifecycles-compat": "^1.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
     "jest-cli": "^22.1.4",
     "less": "^2.7.3",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0",
-    "react-test-renderer": "^16.2.0"
+    "react-dom": "^16.2.0"
   },
   "peerDependencies": {
     "react": ">=15.5",

--- a/sample/package.json
+++ b/sample/package.json
@@ -14,9 +14,9 @@
   "license": "MIT",
   "dependencies": {
     "prop-types": "^15.6.0",
-    "react": "^16.2.0",
+    "react": "^16.3.0",
     "react-time-picker": "latest",
-    "react-dom": "^16.2.0"
+    "react-dom": "^16.3.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/src/TimeInput.jsx
+++ b/src/TimeInput.jsx
@@ -61,28 +61,44 @@ const removeUnwantedCharacters = str => str
   .join('');
 
 export default class TimeInput extends Component {
-  state = {
-    hour: null,
-    minute: null,
-    second: null,
-  }
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const nextState = {};
 
-  componentWillMount() {
-    this.updateValues();
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const { value: nextValue } = nextProps;
-    const { value } = this.props;
-
-    if (
-      // Toggling clock visibility resets values
-      (nextProps.isClockOpen !== this.props.isClockOpen) ||
-      hoursAreDifferent(nextValue, value)
-    ) {
-      this.updateValues(nextProps);
+    /**
+     * If isClockOpen flag has changed, we have to update it.
+     * It's saved in state purely for use in getDerivedStateFromProps.
+     */
+    if (nextProps.isClockOpen !== prevState.isClockOpen) {
+      nextState.isClockOpen = nextProps.isClockOpen;
     }
+
+    /**
+     * If the next value is different from the current one  (with an exception of situation in
+     * which values provided are limited by minDate and maxDate so that the dates are the same),
+     * get a new one.
+     */
+    const nextValue = nextProps.value;
+    if (
+      // Toggling calendar visibility resets values
+      nextState.isClockOpen || // Flag was toggled
+      hoursAreDifferent(nextValue, prevState.value)
+    ) {
+      if (nextValue) {
+        nextState.hour = getHours(nextValue);
+        nextState.minute = getMinutes(nextValue);
+        nextState.second = getSeconds(nextValue);
+      } else {
+        nextState.hour = null;
+        nextState.minute = null;
+        nextState.second = null;
+      }
+      nextState.value = nextValue;
+    }
+
+    return nextState;
   }
+
+  state = {};
 
   /**
    * Gets current value in a desired format.
@@ -156,16 +172,6 @@ export default class TimeInput extends Component {
         this[`${ref.name}Input`] = ref;
       },
     };
-  }
-
-  updateValues(props = this.props) {
-    const { value } = props;
-
-    this.setState({
-      hour: value ? getHours(value) : null,
-      minute: value ? getMinutes(value) : null,
-      second: value ? getSeconds(value) : null,
-    });
   }
 
   onKeyDown = (event) => {

--- a/src/TimeInput.jsx
+++ b/src/TimeInput.jsx
@@ -113,8 +113,7 @@ export default class TimeInput extends Component {
    * Returns value type that can be returned with currently applied settings.
    */
   get valueType() {
-    const { maxDetail } = this.props;
-    return maxDetail;
+    return this.props.maxDetail;
   }
 
   get nativeValueParser() {

--- a/src/TimeInput.jsx
+++ b/src/TimeInput.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import Divider from './Divider';
@@ -60,7 +60,7 @@ const removeUnwantedCharacters = str => str
   ))
   .join('');
 
-export default class TimeInput extends Component {
+export default class TimeInput extends PureComponent {
   static getDerivedStateFromProps(nextProps, prevState) {
     const nextState = {};
 

--- a/src/TimePicker.jsx
+++ b/src/TimePicker.jsx
@@ -12,9 +12,18 @@ import { isTime } from './shared/propTypes';
 const allViews = ['hour', 'minute', 'second'];
 
 export default class TimePicker extends PureComponent {
-  state = {
-    isOpen: this.props.isOpen,
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.isOpen !== prevState.propsIsOpen) {
+      return {
+        isOpen: nextProps.isOpen,
+        propsIsOpen: nextProps.isOpen,
+      };
+    }
+
+    return null;
   }
+
+  state = {};
 
   componentDidMount() {
     document.addEventListener('mousedown', this.onClick);
@@ -22,14 +31,6 @@ export default class TimePicker extends PureComponent {
 
   componentWillUnmount() {
     document.removeEventListener('mousedown', this.onClick);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const { props } = this;
-
-    if (nextProps.isOpen !== props.isOpen) {
-      this.setState({ isOpen: nextProps.isOpen });
-    }
   }
 
   onClick = (event) => {

--- a/test/LocaleOptions.jsx
+++ b/test/LocaleOptions.jsx
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-export default class LocaleOptions extends Component {
+export default class LocaleOptions extends PureComponent {
   onChange = (event) => {
     let { value: locale } = event.target;
 

--- a/test/MaxDetailOptions.jsx
+++ b/test/MaxDetailOptions.jsx
@@ -1,9 +1,9 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 const allViews = ['hour', 'minute', 'second'];
 
-export default class MaxDetailOptions extends Component {
+export default class MaxDetailOptions extends PureComponent {
   onChange = (event) => {
     const { value } = event.target;
 

--- a/test/Test.jsx
+++ b/test/Test.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import TimePicker from 'react-time-picker/src/entry.nostyle';
 import 'react-time-picker/src/TimePicker.less';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -15,7 +15,7 @@ import { getHoursMinutesSeconds } from '../src/shared/dates';
 
 const now = new Date();
 
-export default class Test extends Component {
+export default class Test extends PureComponent {
   state = {
     locale: null,
     maxTime: null,

--- a/test/ValidityOptions.jsx
+++ b/test/ValidityOptions.jsx
@@ -1,9 +1,9 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import { isTime } from '../src/shared/propTypes';
 
-export default class ValidityOptions extends Component {
+export default class ValidityOptions extends PureComponent {
   onMinChange = (event) => {
     const { value } = event.target;
 

--- a/test/ValueOptions.jsx
+++ b/test/ValueOptions.jsx
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-export default class ValueOptions extends Component {
+export default class ValueOptions extends PureComponent {
   setValue = value => this.props.setState({ value });
 
   onChange = (event) => {

--- a/test/index.jsx
+++ b/test/index.jsx
@@ -1,5 +1,10 @@
-import React from 'react';
+import React, { StrictMode } from 'react';
 import { render } from 'react-dom';
 import Test from './Test';
 
-render(<Test />, document.getElementById('react-container'));
+render(
+  <StrictMode>
+    <Test />
+  </StrictMode>,
+  document.getElementById('react-container'),
+);

--- a/test/package.json
+++ b/test/package.json
@@ -14,9 +14,9 @@
   "license": "MIT",
   "dependencies": {
     "prop-types": "^15.6.0",
-    "react": "^16.2.0",
+    "react": "^16.3.0",
     "react-time-picker": "latest",
-    "react-dom": "^16.2.0"
+    "react-dom": "^16.3.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3690,9 +3690,9 @@ react-clock@^2.2.1:
     merge-class-names "^1.1.1"
     prop-types "^15.6.0"
 
-react-dom@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+react-dom@^16.3.0:
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.0.tgz#b318e52184188ecb5c3e81117420cca40618643e"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -3716,9 +3716,9 @@ react-test-renderer@^16.0.0-0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+react@^16.3.0:
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.0.tgz#fc5a01c68f91e9b38e92cf83f7b795ebdca8ddff"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3699,6 +3699,10 @@ react-dom@^16.3.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-lifecycles-compat@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-1.1.0.tgz#6641d0709bd5505329b5c90322147ef2d343485c"
+
 react-reconciler@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.7.0.tgz#9614894103e5f138deeeb5eabaf3ee80eb1d026d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3708,7 +3708,7 @@ react-reconciler@^0.7.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-test-renderer@^16.0.0-0, react-test-renderer@^16.2.0:
+react-test-renderer@^16.0.0-0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
   dependencies:


### PR DESCRIPTION
Fixes #5.

* Removed all `componentWillMount` and `componentWillReceiveProps` lifecycle methods
* **Support for React 16.2 and lower is continued**
* Removed all deprecation warnings that would affect React 16.4 and up.