### PR TITLE
Add 'disableClock' prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Displays an input field complete with custom inputs, native input and a clock.
 |isOpen|Defines whether the calendar should be opened. Defaults to false.|`true`|
 |locale|Defines which locale should be used by the time picker and the calendar. Can be any [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag). Defaults to user's browser settings.|`"hu-HU"`|
 |maxDetail|Defines how detailed time picking shall be. Can be "hour", "minute" or "second". Defaults to "minute".|`"second"`|
+|disableClock|Defines whether the clock should be disabled. Defaults to false.|`true`|
 |maxTime|Defines maximum time that the user can select.|<ul><li>Date: `new Date()`</li><li>String: `"22:15:00"`</li></ul>|
 |minTime|Defines minimum date that the user can select.|<ul><li>Date: `new Date()`</li><li>String: `"22:15:00"`</li></ul>|
 |name|Defines input name. Defaults to "time".|`"myCustomName"`|

--- a/src/TimePicker.jsx
+++ b/src/TimePicker.jsx
@@ -136,17 +136,18 @@ export default class TimePicker extends PureComponent {
   renderClock() {
     const { isOpen } = this.state;
 
-    if (isOpen === null) {
-      return null;
-    }
-
     const {
       clockClassName,
       className: timePickerClassName, // Unused, here to exclude it from clockProps
       maxDetail,
       onChange,
+      disableClock,
       ...clockProps
     } = this.props;
+
+    if (isOpen === null || disableClock) {
+      return null;
+    }
 
     const className = 'react-time-picker__clock';
 
@@ -247,6 +248,7 @@ TimePicker.propTypes = {
   isOpen: PropTypes.bool,
   locale: PropTypes.string,
   maxDetail: PropTypes.oneOf(allViews),
+  disableClock: PropTypes.bool,
   maxTime: isTime,
   minTime: isTime,
   name: PropTypes.string,

--- a/src/__tests__/TimePicker.jsx
+++ b/src/__tests__/TimePicker.jsx
@@ -104,6 +104,16 @@ describe('TimePicker', () => {
     expect(clock).toHaveLength(1);
   });
 
+  it('does not render Clock component when given disableClock flag', () => {
+    const component = mount(
+      <TimePicker disableClock />
+    );
+
+    const clock = component.find('Clock');
+
+    expect(clock).toHaveLength(0);
+  });
+
   it('opens Clock component when given isOpen flag by changing props', () => {
     const component = mount(
       <TimePicker />


### PR DESCRIPTION
Hi @wojtekmaj, would it be possible to add the `disableClock` prop to this repo too, as we did with 
[wojtekmaj/react-datetime-picker](https://github.com/wojtekmaj/react-datetime-picker/pull/27)?

Potentially closes #9 