### PR TITLE
Fixing 508 accessibility errors reported by Wave

### DIFF
--- a/src/TimeInput/AmPm.jsx
+++ b/src/TimeInput/AmPm.jsx
@@ -38,6 +38,7 @@ class AmPm extends PureComponent {
         )}
         disabled={disabled}
         name={name}
+        aria-label="Designate as AM or PM"
         onChange={onChange}
         ref={(ref) => {
           if (itemRef) {

--- a/src/TimeInput/Hour12Input.jsx
+++ b/src/TimeInput/Hour12Input.jsx
@@ -66,6 +66,7 @@ export default class Hour12Input extends PureComponent {
       <Input
         name="hour12"
         nameForClass="hour"
+        ariaLabel="Time picker for 12-hour format"
         max={maxHour}
         min={minHour}
         value={value12}

--- a/src/TimeInput/Hour24Input.jsx
+++ b/src/TimeInput/Hour24Input.jsx
@@ -37,6 +37,7 @@ export default class Hour24Input extends PureComponent {
       <Input
         name="hour24"
         nameForClass="hour"
+        ariaLabel="Time picker for 24-hour format"
         max={maxHour}
         min={minHour}
         {...otherProps}

--- a/src/TimeInput/Input.jsx
+++ b/src/TimeInput/Input.jsx
@@ -6,10 +6,10 @@ import updateInputWidth from 'update-input-width';
 const select = element => element && element.select();
 
 const Input = ({
+  ariaLabel,
   className,
   disabled,
   itemRef,
-  ariaLabel,
   max,
   min,
   name,
@@ -62,10 +62,10 @@ const Input = ({
 };
 
 Input.propTypes = {
+  ariaLabel: PropTypes.string,
   className: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   itemRef: PropTypes.func,
-  ariaLabel: PropTypes.string,
   max: PropTypes.number,
   min: PropTypes.number,
   onChange: PropTypes.func,

--- a/src/TimeInput/Input.jsx
+++ b/src/TimeInput/Input.jsx
@@ -9,6 +9,7 @@ const Input = ({
   className,
   disabled,
   itemRef,
+  ariaLabel,
   max,
   min,
   name,
@@ -33,6 +34,7 @@ const Input = ({
         `${className}__${nameForClass || name}`,
         hasLeadingZero && `${className}__input--hasLeadingZero`,
       )}
+      aria-label={ariaLabel}
       disabled={disabled}
       name={name}
       max={max}
@@ -63,6 +65,7 @@ Input.propTypes = {
   className: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   itemRef: PropTypes.func,
+  ariaLabel: PropTypes.string,
   max: PropTypes.number,
   min: PropTypes.number,
   onChange: PropTypes.func,

--- a/src/TimeInput/MinuteInput.jsx
+++ b/src/TimeInput/MinuteInput.jsx
@@ -40,6 +40,7 @@ export default class MinuteInput extends PureComponent {
     return (
       <Input
         name="minute"
+        ariaLabel="Denotes the minute's value"
         max={maxMinute}
         min={minMinute}
         {...otherProps}

--- a/src/TimeInput/NativeInput.jsx
+++ b/src/TimeInput/NativeInput.jsx
@@ -50,6 +50,7 @@ export default class NativeInput extends PureComponent {
     return (
       <input
         type="time"
+        aria-label="Time input"
         disabled={disabled}
         max={maxTime ? nativeValueParser(maxTime) : null}
         min={minTime ? nativeValueParser(minTime) : null}

--- a/src/TimeInput/SecondInput.jsx
+++ b/src/TimeInput/SecondInput.jsx
@@ -47,6 +47,7 @@ export default class SecondInput extends PureComponent {
     return (
       <Input
         name="second"
+        ariaLabel="Denotes the second's value"
         max={maxSecond}
         min={minSecond}
         {...otherProps}

--- a/src/TimePicker.jsx
+++ b/src/TimePicker.jsx
@@ -143,6 +143,7 @@ export default class TimePicker extends PureComponent {
         {clearIcon !== null && (
           <button
             className={`${baseClassName}__clear-button ${baseClassName}__button`}
+            aria-label="Clear"
             disabled={disabled}
             onClick={this.clear}
             onFocus={this.stopPropagation}
@@ -154,6 +155,7 @@ export default class TimePicker extends PureComponent {
         {clockIcon !== null && !disableClock && (
           <button
             className={`${baseClassName}__clock-button ${baseClassName}__button`}
+            aria-label="Show clock"
             disabled={disabled}
             onClick={this.toggleClock}
             onFocus={this.stopPropagation}


### PR DESCRIPTION
This PR aims to fix the errors reported by the Wave plugin for 508 accessibility issues. The one error remaining displayed in the screenshot below is from the sample page and is not part of the TimePicker component.

![image](https://user-images.githubusercontent.com/1120154/57728824-ca097200-7662-11e9-98ec-62aa2797404c.png)
