### PR TITLE
Add support for allowInvalidValues flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Displays an input field complete with custom inputs, native input and a clock.
 
 |Prop name|Description|Default value|Example values|
 |----|----|----|----|
+|allowInvalidValues|Whether entering an invalid value (eg. time outside of a given range) should trigger onChange function.|`false`|`true`|
 |amPmAriaLabel|`aria-label` for the AM/PM select input.|n/a|`"Select AM/PM"`|
 |autoFocus|Automatically focuses the input on mount.|n/a|`true`|
 |className|Class name(s) that will be added along with `"react-time-picker"` to the main React-Time-Picker `<div>` element.|n/a|<ul><li>String: `"class1 class2"`</li><li>Array of strings: `["class1", "class2 class3"]`</li></ul>|

--- a/src/TimeInput.jsx
+++ b/src/TimeInput.jsx
@@ -304,14 +304,14 @@ export default class TimeInput extends PureComponent {
       }
       case 'hour24': {
         this.setState(
-          { hour: value ? parseInt(value, 10) : null },
+          { hour: value },
           this.onChangeExternal,
         );
         break;
       }
       default: {
         this.setState(
-          { [name]: value ? parseInt(value, 10) : null },
+          { [name]: value },
           this.onChangeExternal,
         );
       }

--- a/src/TimeInput.jsx
+++ b/src/TimeInput.jsx
@@ -370,27 +370,33 @@ export default class TimeInput extends PureComponent {
 
     const formElementsWithoutSelect = formElements.slice(0, -1);
 
+    // If date is incomplete, don't trigger onChange…
+    if (formElementsWithoutSelect.some(formElement => !formElement.value)) {
+      // …unless all form elements are empty.
+      if (formElementsWithoutSelect.every(formElement => !formElement.value)) {
+        onChange(null, false);
+      }
+      return;
+    }
+
+    if (!allowInvalidValues && formElements.some(formElement => !formElement.checkValidity())) {
+      return;
+    }
+
     const values = {};
     formElements.forEach((formElement) => {
       // eslint-disable-next-line react/destructuring-assignment
       values[formElement.name] = this.state[formElement.name];
     });
 
-    if (formElementsWithoutSelect.every(formElement => !formElement.value)) {
-      onChange(null, false);
-    } else if (
-      allowInvalidValues
-      || formElements.every(formElement => formElement.value && formElement.checkValidity())
-    ) {
-      const hour = parseInt(values.hour24 || convert12to24(values.hour12, values.amPm) || 0, 10);
-      const minute = parseInt(values.minute || 0, 10);
-      const second = parseInt(values.second || 0, 10);
+    const hour = parseInt(values.hour24 || convert12to24(values.hour12, values.amPm) || 0, 10);
+    const minute = parseInt(values.minute || 0, 10);
+    const second = parseInt(values.second || 0, 10);
 
-      const padStart = num => `0${num}`.slice(-2);
-      const proposedValue = `${padStart(hour)}:${padStart(minute)}:${padStart(second)}`;
-      const processedValue = this.getProcessedValue(proposedValue);
-      onChange(processedValue, false);
-    }
+    const padStart = num => `0${num}`.slice(-2);
+    const proposedValue = `${padStart(hour)}:${padStart(minute)}:${padStart(second)}`;
+    const processedValue = this.getProcessedValue(proposedValue);
+    onChange(processedValue, false);
   }
 
   renderHour = (currentMatch, index) => {

--- a/src/TimeInput.jsx
+++ b/src/TimeInput.jsx
@@ -388,8 +388,10 @@ export default class TimeInput extends PureComponent {
       // eslint-disable-next-line react/destructuring-assignment
       values[formElement.name] = this.state[formElement.name];
     });
+    // eslint-disable-next-line react/destructuring-assignment
+    values.hour = this.state.hour;
 
-    const hour = parseInt(values.hour24 || convert12to24(values.hour12, values.amPm) || 0, 10);
+    const hour = parseInt(values.hour || 0, 10);
     const minute = parseInt(values.minute || 0, 10);
     const second = parseInt(values.second || 0, 10);
 

--- a/src/TimeInput.jsx
+++ b/src/TimeInput.jsx
@@ -372,7 +372,8 @@ export default class TimeInput extends PureComponent {
 
     const values = {};
     formElements.forEach((formElement) => {
-      values[formElement.name] = formElement.value;
+      // eslint-disable-next-line react/destructuring-assignment
+      values[formElement.name] = this.state[formElement.name];
     });
 
     if (formElementsWithoutSelect.every(formElement => !formElement.value)) {

--- a/src/TimeInput.jsx
+++ b/src/TimeInput.jsx
@@ -354,7 +354,7 @@ export default class TimeInput extends PureComponent {
    * calls props.onChange.
    */
   onChangeExternal = () => {
-    const { onChange } = this.props;
+    const { allowInvalidValues, onChange } = this.props;
 
     if (!onChange) {
       return;
@@ -378,7 +378,8 @@ export default class TimeInput extends PureComponent {
     if (formElementsWithoutSelect.every(formElement => !formElement.value)) {
       onChange(null, false);
     } else if (
-      formElements.every(formElement => formElement.value && formElement.checkValidity())
+      allowInvalidValues
+      || formElements.every(formElement => formElement.value && formElement.checkValidity())
     ) {
       const hour = parseInt(values.hour24 || convert12to24(values.hour12, values.amPm) || 0, 10);
       const minute = parseInt(values.minute || 0, 10);
@@ -578,6 +579,7 @@ TimeInput.defaultProps = {
 };
 
 TimeInput.propTypes = {
+  allowInvalidValues: PropTypes.bool,
   amPmAriaLabel: PropTypes.string,
   autoFocus: PropTypes.bool,
   className: PropTypes.string.isRequired,

--- a/src/TimeInput/Hour12Input.jsx
+++ b/src/TimeInput/Hour12Input.jsx
@@ -58,6 +58,8 @@ export default function Hour12Input({
   );
 }
 
+const isNumberOrString = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
+
 Hour12Input.propTypes = {
   amPm: PropTypes.string,
   ariaLabel: PropTypes.string,
@@ -73,5 +75,5 @@ Hour12Input.propTypes = {
   placeholder: PropTypes.string,
   required: PropTypes.bool,
   showLeadingZeros: PropTypes.bool,
-  value: PropTypes.number,
+  value: isNumberOrString,
 };

--- a/src/TimeInput/Hour24Input.jsx
+++ b/src/TimeInput/Hour24Input.jsx
@@ -27,6 +27,8 @@ export default function Hour24Input({
   );
 }
 
+const isNumberOrString = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
+
 Hour24Input.propTypes = {
   ariaLabel: PropTypes.string,
   className: PropTypes.string.isRequired,
@@ -41,5 +43,5 @@ Hour24Input.propTypes = {
   placeholder: PropTypes.string,
   required: PropTypes.bool,
   showLeadingZeros: PropTypes.bool,
-  value: PropTypes.number,
+  value: isNumberOrString,
 };

--- a/src/TimeInput/Input.jsx
+++ b/src/TimeInput/Input.jsx
@@ -124,6 +124,8 @@ export default function Input({
   ];
 }
 
+const isNumberOrString = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
+
 Input.propTypes = {
   ariaLabel: PropTypes.string,
   className: PropTypes.string.isRequired,
@@ -136,5 +138,5 @@ Input.propTypes = {
   required: PropTypes.bool,
   showLeadingZeros: PropTypes.bool,
   step: PropTypes.number,
-  value: PropTypes.number,
+  value: isNumberOrString,
 };

--- a/src/TimeInput/MinuteInput.jsx
+++ b/src/TimeInput/MinuteInput.jsx
@@ -32,11 +32,13 @@ export default function MinuteInput({
   );
 }
 
+const isNumberOrString = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
+
 MinuteInput.propTypes = {
   ariaLabel: PropTypes.string,
   className: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
-  hour: PropTypes.number,
+  hour: isNumberOrString,
   itemRef: PropTypes.func,
   maxTime: isTime,
   minTime: isTime,
@@ -46,5 +48,5 @@ MinuteInput.propTypes = {
   placeholder: PropTypes.string,
   required: PropTypes.bool,
   showLeadingZeros: PropTypes.bool,
-  value: PropTypes.number,
+  value: isNumberOrString,
 };

--- a/src/TimeInput/SecondInput.jsx
+++ b/src/TimeInput/SecondInput.jsx
@@ -33,20 +33,22 @@ export default function SecondInput({
   );
 }
 
+const isNumberOrString = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
+
 SecondInput.propTypes = {
   ariaLabel: PropTypes.string,
   className: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
-  hour: PropTypes.number,
+  hour: isNumberOrString,
   itemRef: PropTypes.func,
   maxTime: isTime,
   minTime: isTime,
-  minute: PropTypes.number,
+  minute: isNumberOrString,
   onChange: PropTypes.func,
   onKeyDown: PropTypes.func,
   onKeyUp: PropTypes.func,
   placeholder: PropTypes.string,
   required: PropTypes.bool,
   showLeadingZeros: PropTypes.bool,
-  value: PropTypes.number,
+  value: isNumberOrString,
 };

--- a/src/TimePicker.jsx
+++ b/src/TimePicker.jsx
@@ -115,6 +115,7 @@ export default class TimePicker extends PureComponent {
 
   renderInputs() {
     const {
+      allowInvalidValues,
       amPmAriaLabel,
       autoFocus,
       clearAriaLabel,
@@ -162,6 +163,7 @@ export default class TimePicker extends PureComponent {
         <TimeInput
           {...ariaLabelProps}
           {...placeholderProps}
+          allowInvalidValues={allowInvalidValues}
           autoFocus={autoFocus}
           className={`${baseClassName}__inputGroup`}
           disabled={disabled}
@@ -315,6 +317,7 @@ const isValue = PropTypes.oneOfType([
 ]);
 
 TimePicker.propTypes = {
+  allowInvalidValues: PropTypes.bool,
   amPmAriaLabel: PropTypes.string,
   autoFocus: PropTypes.bool,
   className: PropTypes.oneOfType([


### PR DESCRIPTION
Allows invalid (out of range) values to trigger onChange callback.

Side effect: Values are no longer enforced to be between minDate and maxDate. Still, if input validation was correct, these values shouldn't be invalid in the first place.