### PR TITLE
Fix  - Focus jumps from hours field to seconds field, missing the minutes field.

### DIFF
--- a/src/TimeInput.jsx
+++ b/src/TimeInput.jsx
@@ -308,7 +308,7 @@ export default class TimeInput extends PureComponent {
       return;
     }
 
-    const { value } = input;
+    const { value, max } = input;
     const max = input.getAttribute('max');
 
     /**
@@ -320,7 +320,9 @@ export default class TimeInput extends PureComponent {
     if (value * 10 > max || value.length >= max.length) {
       const property = 'nextElementSibling';
       const nextInput = findInput(input, property);
-      focus(nextInput);
+      setTimeout(() => {
+        focus(nextInput);
+      }, 250);
     }
   };
 

--- a/src/TimeInput.jsx
+++ b/src/TimeInput.jsx
@@ -308,7 +308,7 @@ export default class TimeInput extends PureComponent {
       return;
     }
 
-    const { value, max } = input;
+    const { value } = input;
     const max = input.getAttribute('max');
 
     /**


### PR DESCRIPTION
https://github.com/wojtekmaj/react-time-picker/issues/282