### PR TITLE
Fix leading zero having different font

### DIFF
--- a/packages/react-time-picker/src/TimePicker.css
+++ b/packages/react-time-picker/src/TimePicker.css
@@ -39,6 +39,7 @@
 .react-time-picker__inputGroup__divider,
 .react-time-picker__inputGroup__leadingZero {
   display: inline-block;
+  font: inherit;
 }
 
 .react-time-picker__inputGroup__input {


### PR DESCRIPTION
# Description
I'd like to start out by saying thanks for putting together this awesome library!

I ran into an intriguing glitch using this library in a project where we have custom fonts. There was inconsistency in the font display for the leading zero in the time input. With some research, I discovered that 'font' for the leading zero was not inherited from its parent.

To solve this, I've added the CSS rule `font: inherit` to the `__inputGroup__leadingZero` class. This aligns the font display of the leading zero with the rest of the input. I believe this fix will make the component more consistent when it comes to font styling.

# Images

### Before
<img width="338" alt="Screenshot 2023-09-04 at 1 13 32 AM" src="https://github.com/wojtekmaj/react-time-picker/assets/36612616/9ffdcc3d-a047-45b3-81b9-c2d86da15a94">

### After
<img width="338" alt="Screenshot 2023-09-04 at 1 13 12 AM" src="https://github.com/wojtekmaj/react-time-picker/assets/36612616/046dcc98-70ef-400a-ab2c-efb18d928a9c">

This ensures the styling consistency between all elements of the component, providing a more predictable experience for future users.
