### PR TITLE
Fix bug when `autoFocus` is set to `true`, and `value` is empty

### DIFF
--- a/packages/react-time-picker/src/TimePicker.tsx
+++ b/packages/react-time-picker/src/TimePicker.tsx
@@ -368,12 +368,12 @@ const TimePicker: React.FC<TimePickerProps> = function TimePicker(props) {
     ...otherProps
   } = props;
 
-  const [isOpen, setIsOpen] = useState<boolean | null>(isOpenProps);
+  const [isOpen, setIsOpen] = useState<boolean | null>(isOpenProps ?? autoFocus ?? null);
   const wrapper = useRef<HTMLDivElement>(null);
   const clockWrapper = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    setIsOpen(isOpenProps);
+    setIsOpen(isOpenProps ?? autoFocus ?? null);
   }, [isOpenProps]);
 
   function openClock({ reason }: { reason: OpenReason }) {


### PR DESCRIPTION
Fix bug when `autoFocus` is set to `true`, and `value` is empty, the initial value typed into the hour input is cleared as soon as you finish typing and move to the minutes input. Will now use `autoFocus` when setting initial value for `isOpen`, if `isOpenProps` is undefined.

Explanation of the bug: The TimePicker input is focused as expected, but the `isOpen` property is not set to `true`. This causes the `isOpen` property to be set to `true` as soon as you land on the second input (minutes), which again leads to the hours being cleared.